### PR TITLE
`import.meta.url` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # cloudflare-workers-demo
+
 A simple demo for hosting with cloudflare workers

--- a/functions/api/new-url.js
+++ b/functions/api/new-url.js
@@ -1,0 +1,5 @@
+const dataUrl = new URL('../public/data.json', import.meta.url);
+
+export function onRequest(context) {
+  return new Response(dataUrl.href);
+}

--- a/public/data.json
+++ b/public/data.json
@@ -1,0 +1,3 @@
+{
+  "message": "I was imported with new URL + import.meta.url"
+}

--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,7 @@
     <ul>
       <li>Hello World API - <code>/api/hello</code></li>
       <li>Greeting API - <code>/api/greeting?name=xxx</code></li>
+      <li>New URL API - <code>/api/new-url</code></li>
     </ul>
   </body>
 </html>


### PR DESCRIPTION
Getting this error when deploying using `new URL` + `import.meta.url`
```sh

11:31:48.024 | Successfully read wrangler.toml file.
-- | --
11:31:48.107 | No build command specified. Skipping build step.
11:31:48.108 | Found Functions directory at /functions. Uploading.
11:31:48.114 | ⛅️ wrangler 3.76.0
11:31:48.115 | -------------------
11:31:49.030 | ✨ Compiled Worker successfully
11:31:49.088 | Validating asset output directory
11:31:50.684 | Deploying your site to Cloudflare's global network...
11:31:53.306 | Uploading... (0/2)
11:31:53.617 | Uploading... (1/2)
11:31:53.772 | Uploading... (2/2)
11:31:53.772 | ✨ Success! Uploaded 2 files (0.85 sec)
11:31:53.772 |  
11:31:54.010 | ✨ Upload complete!
11:31:55.627 | Success: Assets published!
11:31:56.564 | Error: Failed to publish your Function. Got error: Uncaught TypeError: Invalid URL string.   at functionsWorker-0.6355073388900252.js:20:15
```

----

Waiting on upstream - https://github.com/cloudflare/workerd/issues/2963